### PR TITLE
Fix bug for reading source settings set by user

### DIFF
--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -1104,8 +1104,11 @@ class Couple_openmc(object):
         ll = self.bounding_box[0]
         ur = self.bounding_box[1]
         #uniform_dist = openmc.stats.Box(ll, ur, only_fissionable=True)
-        #point = openmc.stats.Point(xyz=(0.0, 0.0, 0.0))
-        settings.source = openmc.source.Source.from_xml_element(source)
+        if source is None:
+            point = openmc.stats.Point(xyz=(0.0, 0.0, 0.0))
+            settings.source = openmc.source.Source(space=point)
+        else:
+            settings.source = openmc.source.Source.from_xml_element(source)
         # To reduce the size of the statepoint file
         settings.sourcepoint['write'] = False
 

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -1084,6 +1084,7 @@ class Couple_openmc(object):
         tree = ET.parse(file_path)
         root = tree.getroot()
         settings = openmc.Settings()
+        source = None
 
         for child in root:
             if child.tag == 'particles':

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -1095,6 +1095,8 @@ class Couple_openmc(object):
             if child.tag == 'inactive':
                 settings.inactive = int(child.text)
                 self.inactive = int(child.text)
+            if child.tag == 'source':
+                source = child
 
         settings.output = {'tallies': False}
         settings.temperature = {'method':'nearest', 'tolerance': self.tolerance}
@@ -1102,8 +1104,8 @@ class Couple_openmc(object):
         ll = self.bounding_box[0]
         ur = self.bounding_box[1]
         #uniform_dist = openmc.stats.Box(ll, ur, only_fissionable=True)
-        point = openmc.stats.Point(xyz=(0.0, 0.0, 0.0))
-        settings.source = openmc.source.Source(space=point)
+        #point = openmc.stats.Point(xyz=(0.0, 0.0, 0.0))
+        settings.source = openmc.source.Source.from_xml_element(source)
         # To reduce the size of the statepoint file
         settings.sourcepoint['write'] = False
 


### PR DESCRIPTION
Source settings specified by the user are now read correctly by onix and not overwritten with a point source.