### PR TITLE
Fix possible material mixup in _add_zero_dens_nuclides

### DIFF
--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -704,7 +704,9 @@ class Couple_openmc(object):
                 material.add_nuclide(nucl, self.zero_dens_1_atm)
 
         # Material is rename 'cell name' + 'mat'
-        # New material id is 'mat id' + 'cell id'
+        # New material id is 'mat id' + 'cell id' by default
+        # If new id is already in use additional zeroes are added inbetween
+        # composite ids until the resulting id is not already in use
         material.name = '{} mat'.format(cell_name)
         additional_zeroes = ''
         while int('{}{}{}'.format(material.id, additional_zeroes, cell.id)) in material.used_ids:

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -708,7 +708,7 @@ class Couple_openmc(object):
         material.name = '{} mat'.format(cell_name)
         additional_zeroes=''
         while int('{}{}{}'.format(material.id, additional_zeroes, cell.id)) in material.used_ids:
-            additional_zeroes=additional_zeroes+'0'
+            additional_zeroes = additional_zeroes + '0'
         material.id = int('{}{}{}'.format(material.id, additional_zeroes, cell.id))
 
         # Here, we overwrite the original material object with a copy which id and name have been modified

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -706,7 +706,7 @@ class Couple_openmc(object):
         # Material is rename 'cell name' + 'mat'
         # New material id is 'mat id' + 'cell id'
         material.name = '{} mat'.format(cell_name)
-        additional_zeroes=''
+        additional_zeroes = ''
         while int('{}{}{}'.format(material.id, additional_zeroes, cell.id)) in material.used_ids:
             additional_zeroes = additional_zeroes + '0'
         material.id = int('{}{}{}'.format(material.id, additional_zeroes, cell.id))

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -709,7 +709,7 @@ class Couple_openmc(object):
         additional_zeroes=''
         while int('{}{}{}'.format(material.id, additional_zeroes, cell.id)) in material.used_ids:
             additional_zeroes=additional_zeroes+'0'
-        material.id = int('{}'.format(material.id)+additional_zeroes+'{}'.format(cell.id))
+        material.id = int('{}{}{}'.format(material.id, additional_zeroes, cell.id))
 
         # Here, we overwrite the original material object with a copy which id and name have been modified
         # to reflect the fact that this material object is specific to this cell

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -706,7 +706,10 @@ class Couple_openmc(object):
         # Material is rename 'cell name' + 'mat'
         # New material id is 'mat id' + 'cell id'
         material.name = '{} mat'.format(cell_name)
-        material.id = int('{}{}'.format(material.id, cell.id))
+        additional_zeroes=''
+        while int('{}'.format(material.id)+additional_zeroes+'{}'.format(cell.id)) in material.used_ids:
+            additional_zeroes=additional_zeroes+'0'
+        material.id = int('{}'.format(material.id)+additional_zeroes+'{}'.format(cell.id))
 
         # Here, we overwrite the original material object with a copy which id and name have been modified
         # to reflect the fact that this material object is specific to this cell

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -707,7 +707,7 @@ class Couple_openmc(object):
         # New material id is 'mat id' + 'cell id'
         material.name = '{} mat'.format(cell_name)
         additional_zeroes=''
-        while int('{}'.format(material.id)+additional_zeroes+'{}'.format(cell.id)) in material.used_ids:
+        while int('{}{}{}'.format(material.id, additional_zeroes, cell.id)) in material.used_ids:
             additional_zeroes=additional_zeroes+'0'
         material.id = int('{}'.format(material.id)+additional_zeroes+'{}'.format(cell.id))
 


### PR DESCRIPTION
The _add_zero_dens_nuclides function now checks whether the newly created material ID is already in use, and if so adds in additional zeroes between material and cell ID until this is not the case. This avoids having materials overwritten/wrong materials filled into cells by accident.