### PR TITLE
Added option to redirect ONIX output

### DIFF
--- a/onix/cell.py
+++ b/onix/cell.py
@@ -2629,7 +2629,7 @@ class Cell(object):
     def _copy_cell_folders_to_step_folder(self, s, prefix=None):
 
         cell_folder_path = self.folder_path
-	if prefix!=None:
+        if prefix!=None:
             shutil.copytree(cell_folder_path, os.getcwd() + '/' + prefix[:-1] + '/step_{}/{}_cell'.format(s, self.name))
         else:
             shutil.copytree(cell_folder_path, os.getcwd() + '/step_{}/{}_cell'.format(s, self.name))

--- a/onix/cell.py
+++ b/onix/cell.py
@@ -2626,10 +2626,13 @@ class Cell(object):
         utils.gen_cell_folder(cell_name)
         self._folder_path = utils.get_cell_folder_path(cell_name)
 
-    def _copy_cell_folders_to_step_folder(self, s):
+    def _copy_cell_folders_to_step_folder(self, s, prefix=None):
 
         cell_folder_path = self.folder_path
-        shutil.copytree(cell_folder_path, os.getcwd() + '/step_{}/{}_cell'.format(s, self.name))
+	if prefix!=None:
+            shutil.copytree(cell_folder_path, os.getcwd() + '/' + prefix[:-1] + '/step_{}/{}_cell'.format(s, self.name))
+        else:
+            shutil.copytree(cell_folder_path, os.getcwd() + '/step_{}/{}_cell'.format(s, self.name))
         shutil.rmtree(cell_folder_path)
 
     # def _gen_output_summary_folder(self):

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -1655,7 +1655,7 @@ class Couple_openmc(object):
             self._run_openmc()
             self._set_tallies_to_bucells(s)
             self._step_normalization(s)
-            self._copy_MC_files(s)
+            self._copy_MC_files(s,prefix)
             print (('\n\n\n=== Salameche Burn {} ===\n\n\n'.format(s)))
             print (utils.printer.salameche_header)
             salameche.burn_step(system, s, 'couple', prefix)

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -1568,6 +1568,11 @@ class Couple_openmc(object):
 
     def burn(self, prefix=None):
         """Launches the coupled simulation.
+                
+        Parameters
+        ----------
+        prefix: str
+            Prefix for standard ONIX output paths
         """
 
         start_time = time.time()

--- a/onix/salameche/burn.py
+++ b/onix/salameche/burn.py
@@ -9,7 +9,7 @@ from . import py_pade
 
 # This function is in fact not used anymore.
 # Might need to be removed
-def burn(system):
+def burn(system, prefix=None):
     """Depletes a System Object according to its associated Sequence object.
     """
     sequence = system.sequence
@@ -28,15 +28,15 @@ def burn(system):
 
         print ('\n\n\n\n STEP {}\n\n\n\n'.format(s))
 
-        sequence._gen_step_folder(s)
-        burn_step(system, s, mode='stand alone')
+        sequence._gen_step_folder(s, prefix)
+        burn_step(system, s, mode='stand alone', prefix=prefix)
 
-    system._gen_output_summary_folder()
+    system._gen_output_summary_folder(prefix)
     system._print_summary_allreacs_rank()
     system._print_summary_subdens()
     system._print_summary_dens()
 
-def burn_step(system, s, mode):
+def burn_step(system, s, mode, prefix=None):
 
     """Depletes the system for macrostep s.
 
@@ -64,7 +64,7 @@ def burn_step(system, s, mode):
 
     if reac_rank == 'on':
         system._print_current_allreacs_rank()
-    system._copy_cell_folders_to_step_folder(s)
+    system._copy_cell_folders_to_step_folder(s, prefix)
 
 def burn_cell(bucell, s, mode, reac_rank):
 

--- a/onix/salameche/burn.py
+++ b/onix/salameche/burn.py
@@ -11,6 +11,11 @@ from . import py_pade
 # Might need to be removed
 def burn(system, prefix=None):
     """Depletes a System Object according to its associated Sequence object.
+    
+    Parameters
+    ----------
+    prefix: str
+        Prefix for standard ONIX output paths
     """
     sequence = system.sequence
     steps_number = sequence.steps_number
@@ -48,6 +53,8 @@ def burn_step(system, s, mode, prefix=None):
         Macrostep number
     mode: str
         'stand alone' or 'couple'
+    prefix: str
+        Prefix for standard ONIX output paths
     """
 
     bucell_list = system.get_bucell_list()

--- a/onix/sequence.py
+++ b/onix/sequence.py
@@ -847,10 +847,12 @@ class Sequence(object):
     #     name = 'step_0'
     #     utils.gen_folder(name)
 
-    def _gen_step_folder(self, s):
+    def _gen_step_folder(self, s, prefix=None):
 
         # Folder numbering starts with 1 not 0
         name = 'step_{}'.format(s)
+        if prefix!=None:
+            name = prefix + name
         utils.gen_folder(name)
 
     def microsteps_number(self, s):

--- a/onix/system.py
+++ b/onix/system.py
@@ -454,16 +454,18 @@ class System(object):
         write_file.write(txt)
         write_file.close()
 
-    def _copy_cell_folders_to_step_folder(self, s):
+    def _copy_cell_folders_to_step_folder(self, s, prefix=None):
 
         bucell_dict = self.bucell_dict
         for bucell_id in bucell_dict:
             bucell = bucell_dict[bucell_id]
-            bucell._copy_cell_folders_to_step_folder(s)
+            bucell._copy_cell_folders_to_step_folder(s, prefix)
 
-    def _gen_output_summary_folder(self):
+    def _gen_output_summary_folder(self, prefix=None):
 
         name = 'output_summary'
+        if prefix!=None:
+            name = prefix + name
         self._output_summary_path = utils.get_folder_path(name)
         utils.gen_folder(name)
 


### PR DESCRIPTION
The user can now provide the burn routine with a prefix - relative to the current working directory - that the ONIX output is redirected to. The structure of the output itself remains unchanged. Note that ONIX still works and temporarily creates and reads files in the current directory, and as such running several instances of ONIX at the same time from the same directory will still cause issues, regardless of their final output directories being different. I still think it is a nice QOL addition.