### PR TITLE
Overhaul of plot_bucell_nuclide_network utility

### DIFF
--- a/onix/utils/data_processor.py
+++ b/onix/utils/data_processor.py
@@ -156,7 +156,7 @@ def plot_bucell_nuclide_network(nuclide, step, path, cell, threshold, threshold_
             reaction_val = tuples[1]
             # if reaction_val == 0.0:
             #   continue    
-            if threshold_mode=='absolute':
+            if threshold_mode == 'absolute':
                 if reaction_val < threshold:
                     continue
             else:

--- a/onix/utils/data_processor.py
+++ b/onix/utils/data_processor.py
@@ -206,7 +206,7 @@ def plot_bucell_nuclide_network(nuclide, step, path, cell, threshold, threshold_
     nx.draw(G,pos, node_size=6000, node_color = node_color, font_size = 5)
 
     plt.show()
-    plt.savefig('Nuclide_network_{}_{}_step_{}.format(nuclide, cell, step))
+    plt.savefig('Nuclide_network_{}_{}_step_{}.png'.format(nuclide, cell, step))
     plt.close()
 
 def plot_nuclide_dens_from_passport(bucell, nuclide):

--- a/onix/utils/data_processor.py
+++ b/onix/utils/data_processor.py
@@ -145,7 +145,7 @@ def plot_bucell_nuclide_network(nuclide, step, path, cell, threshold, threshold_
             reaction_val = tuples[1]
             # if reaction_val == 0.0:
             #   continue    
-            if threshold_mode='absolute' and reaction_val < threshold:
+            if threshold_mode == 'absolute' and reaction_val < threshold:
                 continue    
             prod_total += reaction_val
 

--- a/onix/utils/data_processor.py
+++ b/onix/utils/data_processor.py
@@ -65,7 +65,7 @@ def read_nuclide_reac_rank(nuclide, step, path):
 
     return [destruction, production]
 
-def plot_bucell_nuclide_network(nuclide, step, path, cell, threshold, threshold_mode='absolute'):
+def plot_bucell_nuclide_network(nuclide, step, path, cell, threshold, threshold_mode='absolute', disable_show=False):
     
     """Plots a network diagram of the destruction and production reaction rates of a specified nuclide at a given macrostep for a given BUCell. Reaction rates are in :math:`barn^{-2}cm^{-1}s^{-1}`. Production channels are indicated with the name of the parent nuclide, destruction channels are indicated with the name of the reaction.
 
@@ -205,7 +205,8 @@ def plot_bucell_nuclide_network(nuclide, step, path, cell, threshold, threshold_
     nx.draw_networkx_edges(G,pos)
     nx.draw(G,pos, node_size=6000, node_color = node_color, font_size = 5)
 
-    plt.show()
+    if not disable_show:
+        plt.show()
     plt.savefig('Nuclide_network_{}_{}_step_{}.png'.format(nuclide, cell, step))
     plt.close()
 

--- a/onix/utils/data_processor.py
+++ b/onix/utils/data_processor.py
@@ -119,7 +119,7 @@ def plot_bucell_nuclide_network(nuclide, step, path, cell, threshold, threshold_
         if '-' not in tuples[0]:
             # if tuples[1] == 0.0:
             #   continue
-            if threshold_mode=='absolute' and tuples[1] < threshold:
+            if threshold_mode == 'absolute' and tuples[1] < threshold:
                 continue
             dest_total += tuples[1]
 

--- a/onix/utils/data_processor.py
+++ b/onix/utils/data_processor.py
@@ -128,7 +128,7 @@ def plot_bucell_nuclide_network(nuclide, step, path, cell, threshold, threshold_
         if '-' not in tuples[0]:
             # if tuples[1] == 0.0:
             #   continue
-            if threshold_mode=='absolute'
+            if threshold_mode == 'absolute':
                 if tuples[1] < threshold:
                     continue
             else:

--- a/onix/utils/data_processor.py
+++ b/onix/utils/data_processor.py
@@ -88,7 +88,7 @@ def plot_bucell_nuclide_network(nuclide, step, path, cell, threshold, threshold_
     if threshold_mode not in ['absolute','fraction']:
         print('Threshold mode needs to be given as either \'absolute\' (default) or \'fraction\'!')
         return
-    if threshold_mode=='fraction' and (threshold<0. or threshold>1.):
+    if threshold_mode == 'fraction' and (threshold < 0. or threshold > 1.):
         print('In fraction mode threshold needs to be between 0 and 1!')
         return
               

--- a/onix/utils/data_processor.py
+++ b/onix/utils/data_processor.py
@@ -86,7 +86,7 @@ def plot_bucell_nuclide_network(nuclide, step, path, cell, threshold, threshold_
       
     """
     if threshold_mode not in ['absolute','fraction']:
-        print('Threshold mode needs to be given as either \'absolute\' (default) or \'fraction'!')
+        print('Threshold mode needs to be given as either \'absolute\' (default) or \'fraction\'!')
         return
     if threshold_mode=='fraction' and (threshold<0. or threshold>1.):
         print('In fraction mode threshold needs to be between 0 and 1!')


### PR DESCRIPTION
Made some improvements to the plot_bucell_nuclide_network utility function:
Threshold can now be given as fraction of the total reaction rate instead of absolute reaction rate (the latter is still the default). The nodes in the created plot now form a proper circle, and the plot is created quadratic to avoid distortion of dimensions. Readibility of text has been improved. The plot is now saved for further use. Deleted some useless code snippets.