### PR TITLE
Openmc 0.13.1 compatibility

### DIFF
--- a/onix/cell.py
+++ b/onix/cell.py
@@ -2064,7 +2064,7 @@ class Cell(object):
     #   self._all_nucl = self.get_all_nucl
 
 
-    def _set_MC_tallies(self, mc_nuclide_densities, flux_tally, flux_spectrum_tally, rxn_rate_tally, sampled_isomeric_branching_data, sampled_ng_cross_section_data, xs_mode, s):
+    def _set_MC_tallies(self, flux_tally, flux_spectrum_tally, rxn_rate_tally, sampled_isomeric_branching_data, sampled_ng_cross_section_data, xs_mode, s):
 
         MC_flux = flux_tally.mean[0][0][0]
         self.sequence._set_macrostep_MC_flux(MC_flux)
@@ -2094,11 +2094,6 @@ class Cell(object):
             # But the macro xs need to be divided by 1E-24 and not 0
 
             if nucl_passport.current_dens == 0.0:
-
-                # mc_nuclide_densities gives a tuples where the first element is the nuclide name
-                # and the second element is the density
-                #nucl_dens = mc_nuclide_densities[nucl][1]
-
                 nucl_dens = self.zero_dens_1_atm
             else:
                 nucl_dens = nucl_passport.current_dens

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -1460,16 +1460,11 @@ class Couple_openmc(object):
             # 1E-24 fraction percent does not translate into 1E-24 atm/cm3 always
             # Therefore, the code needs to divide the reaction rate by the correct densities
             # taken from summary.geometry.cell.material
-            cell = summary.geometry.get_cells_by_name(bucell.name)[0]
-            material_dict = cell.get_all_materials()
-            material = material_dict[list(material_dict.keys())[0]]
-            mc_nuclides_densities = material.get_nuclide_atom_densities()
-
             flux_tally = sp.get_tally(name = '{} flux'.format(bucell.name))
             flux_spectrum_tally = sp.get_tally(name = '{} flux spectrum'.format(bucell.name))
             rxn_rate_tally = sp.get_tally(name = '{} rxn rate'.format(bucell.name))
             # H3_rxn_rate_tally = sp.get_tally(name = '{} H3 rxn rate'.format(bucell.name))
-            bucell._set_MC_tallies(mc_nuclides_densities, flux_tally, flux_spectrum_tally, rxn_rate_tally, sampled_isomeric_branching_data, sampled_ng_cross_section_data, xs_mode, s)
+            bucell._set_MC_tallies(flux_tally, flux_spectrum_tally, rxn_rate_tally, sampled_isomeric_branching_data, sampled_ng_cross_section_data, xs_mode, s)
 
         # YOU NEED TO CREATE LIST TO STORE EACH NEW XS
 

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -568,7 +568,10 @@ class Couple_openmc(object):
     def _set_kinf(self):
 
         statepoint = self.statepoint
-        kinf = statepoint.k_combined
+        if ((int(openmc.__version__.split('.')[1]) == 13) and (int(openmc.__version__.split('.')[2]) >= 1)) or (int(openmc.__version__.split('.')[1]) > 13):
+            kinf = statepoint.keff
+        else:
+            kinf = statepoint.k_combined
 
         system = self.system
         sequence = system.sequence

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -913,7 +913,10 @@ class Couple_openmc(object):
                 onix_nucl = utils.openmc_name_to_onix_name(nucl)
                 # if nucl is one of the initial non-zero initial nuclide, pass the density
                 if nucl in init_nucl:
-                    onix_dens_dict[onix_nucl] = openmc_dens_dict[nucl][1]
+                    if ((int(openmc.__version__.split('.')[1]) == 13) and (int(openmc.__version__.split('.')[2]) >= 1)) or (int(openmc.__version__.split('.')[1]) > 13):
+                        onix_dens_dict[onix_nucl] = openmc_dens_dict[nucl]
+                    else:
+                        onix_dens_dict[onix_nucl] = openmc_dens_dict[nucl][1]
                 # if nucl is not one of the non-zero initial nuclide, set densiy to zero
                 else:
                     onix_dens_dict[onix_nucl] = 0.0

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -568,9 +568,10 @@ class Couple_openmc(object):
     def _set_kinf(self):
 
         statepoint = self.statepoint
-        if ((int(openmc.__version__.split('.')[1]) == 13) and (int(openmc.__version__.split('.')[2]) >= 1)) or (int(openmc.__version__.split('.')[1]) > 13):
+        #Criticality attribute naming was changed as of OpenMC 0.13.1
+        try:
             kinf = statepoint.keff
-        else:
+        except AttributeError:
             kinf = statepoint.k_combined
 
         system = self.system
@@ -916,10 +917,11 @@ class Couple_openmc(object):
                 onix_nucl = utils.openmc_name_to_onix_name(nucl)
                 # if nucl is one of the initial non-zero initial nuclide, pass the density
                 if nucl in init_nucl:
-                    if ((int(openmc.__version__.split('.')[1]) == 13) and (int(openmc.__version__.split('.')[2]) >= 1)) or (int(openmc.__version__.split('.')[1]) > 13):
-                        onix_dens_dict[onix_nucl] = openmc_dens_dict[nucl]
-                    else:
+                    #Return format of get_nuclide_atom_densities was changed as of OpenMC 0.13.1
+                    try:
                         onix_dens_dict[onix_nucl] = openmc_dens_dict[nucl][1]
+                    except IndexError:
+                        onix_dens_dict[onix_nucl] = openmc_dens_dict[nucl]
                 # if nucl is not one of the non-zero initial nuclide, set densiy to zero
                 else:
                     onix_dens_dict[onix_nucl] = 0.0


### PR DESCRIPTION
Made ONIX compatible with minor naming and formatting changes introduced with openmc 0.13.1 while retaining backward compatibility