### PR TITLE
Bugfix - cell mixup when adding zero dens nuclides

### DIFF
--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -631,7 +631,7 @@ class Couple_openmc(object):
             #   if bucell_name in self.selected_bucells_nucl_list_dict:
             #       if self.selected_bucells_nucl_list_dict[bucell_name] == 'initial nuclides':
             #           continue
-            cell = summary.geometry.get_cells_by_name(bucell_name)[0]
+            cell = summary.geometry.get_cells_by_name(bucell_name, matching=True)[0]
             self._add_zero_dens_nuclides(cell)
 
 


### PR DESCRIPTION
Fixed a bug that could cause zero dens nuclides to be added to the wrong material. It was caused by cell name strings containing each other and being mixed up on lookup (e.g. 'fuel element' and 'fuel element cladding' - lookup of the first could yield the second since the name contains the desired string) - this would crash ONIX later on since the supposedly changed material would not contain the expected additional nuclides. This is now fixed by requiring an exact match on lookup.