### PR TITLE
Disable step output option

### DIFF
--- a/onix/cell.py
+++ b/onix/cell.py
@@ -1427,7 +1427,6 @@ class Cell(object):
         cell_name = self.name
         passlist = self.passlist
         passport_list = passlist.passport_list
-        cell_folder_path = self.folder_path
         sequence = self.sequence
         time_subseq_mat = sequence.time_subseq_mat
         system_bu_subseq_mat = sequence.system_bu_subseq_mat
@@ -1521,7 +1520,6 @@ class Cell(object):
         cell_name = self.name
         passlist = self.passlist
         passport_list = passlist.passport_list
-        cell_folder_path = self.folder_path
         sequence = self.sequence
         time_seq = sequence.time_seq
         system_bu_seq = sequence.system_bu_seq
@@ -1606,7 +1604,6 @@ class Cell(object):
         cell_name = self.name
         passlist = self.passlist
         passport_list = passlist.passport_list
-        cell_folder_path = self.folder_path
         sequence = self.sequence
         time_seq = sequence.time_seq
         system_bu_seq = sequence.system_bu_seq

--- a/onix/couple/couple_openmc.py
+++ b/onix/couple/couple_openmc.py
@@ -1698,7 +1698,8 @@ class Couple_openmc(object):
         for s in range(1, steps_number+1):
 
             print ('\n\n\n\n====== STEP {}======\n\n\n\n'.format(s))
-            sequence._gen_step_folder(s, prefix)
+            if self._write_step_output:
+                sequence._gen_step_folder(s, prefix)
             print (('\n\n\n=== OpenMC Transport {}===\n\n\n'.format(s)))
             self._change_temperature(s)
             self._run_openmc()

--- a/onix/salameche/burn.py
+++ b/onix/salameche/burn.py
@@ -64,12 +64,13 @@ def burn_step(system, s, mode, prefix=None, step_output=True):
     for bucell in bucell_list:
         print ('\n\n\n\n CELL {}\n\n\n\n'.format(bucell.name))
         # Create and set the folder corresponding to that cell
+        if step_output:
+            bucell._set_folder()
+            bucell._print_xs_lib()
         burn_cell(bucell, s, mode, reac_rank, step_output)
         bucell._change_isotope_density(s)
         bucell._change_total_density(s)
         if step_output:
-            bucell._set_folder()
-            bucell._print_xs_lib()
             bucell._print_substep_dens(s)
 
     if step_output:

--- a/onix/salameche/burn.py
+++ b/onix/salameche/burn.py
@@ -41,7 +41,7 @@ def burn(system, prefix=None):
     system._print_summary_subdens()
     system._print_summary_dens()
 
-def burn_step(system, s, mode, prefix=None):
+def burn_step(system, s, mode, prefix=None, step_output=True):
 
     """Depletes the system for macrostep s.
 
@@ -55,6 +55,8 @@ def burn_step(system, s, mode, prefix=None):
         'stand alone' or 'couple'
     prefix: str
         Prefix for standard ONIX output paths
+    step_output: bool
+        Whether ONIX should write output files for each simulation step
     """
 
     bucell_list = system.get_bucell_list()
@@ -62,18 +64,20 @@ def burn_step(system, s, mode, prefix=None):
     for bucell in bucell_list:
         print ('\n\n\n\n CELL {}\n\n\n\n'.format(bucell.name))
         # Create and set the folder corresponding to that cell
-        bucell._set_folder()
-        bucell._print_xs_lib()
-        burn_cell(bucell, s, mode, reac_rank)
+        burn_cell(bucell, s, mode, reac_rank, step_output)
         bucell._change_isotope_density(s)
         bucell._change_total_density(s)
-        bucell._print_substep_dens(s)
+        if step_output:
+            bucell._set_folder()
+            bucell._print_xs_lib()
+            bucell._print_substep_dens(s)
 
-    if reac_rank == 'on':
-        system._print_current_allreacs_rank()
-    system._copy_cell_folders_to_step_folder(s, prefix)
+    if step_output:
+        if reac_rank == 'on':
+            system._print_current_allreacs_rank()
+        system._copy_cell_folders_to_step_folder(s, prefix)
 
-def burn_cell(bucell, s, mode, reac_rank):
+def burn_cell(bucell, s, mode, reac_rank, step_output=True):
 
     """Depletes a BUCell for macrostep s.
 
@@ -87,6 +91,8 @@ def burn_cell(bucell, s, mode, reac_rank):
         'stand alone' or 'couple'
     reac_rank: str
         'on' or 'off'. If set to 'on', each BUCell will compute production and destruction terms ranking for each nuclide at every macrostep.
+    step_output: bool
+        Whether ONIX should write output files for each simulation step
     """
     # Check if different nuclide lists are coherent with each other
     # This should not be called in burn_cell because bun_cell is in the sequence loop
@@ -108,7 +114,8 @@ def burn_cell(bucell, s, mode, reac_rank):
 
     # Store B and C on compressed txt
     # there needs to be a new matrix print for every step (even substep)
-    mb._print_all_mat_to_text(B, C, bucell, s)
+    if step_output:
+        mb._print_all_mat_to_text(B, C, bucell, s)
 
     if flux_approximation == 'iv':
         for i in range(microsteps_number):

--- a/onix/standalone.py
+++ b/onix/standalone.py
@@ -32,7 +32,7 @@ class Stand_alone(object):
 		self._xs_libs_set = 'no'
 
 		self.system = System(1)
-                self._write_step_output = True
+		self._write_step_output = True
 
 	@property
 	def system(self):

--- a/onix/standalone.py
+++ b/onix/standalone.py
@@ -32,6 +32,7 @@ class Stand_alone(object):
 		self._xs_libs_set = 'no'
 
 		self.system = System(1)
+                self._write_step_output = True
 
 	@property
 	def system(self):
@@ -181,6 +182,10 @@ class Stand_alone(object):
 			bucell_sequence._set_macrostep_flux(system_flux)
 			bucell_sequence._set_macrostep_pow_dens(pow_dens)
 
+	def disable_step_output(self):
+		"""Calling this function will stop ONIX from writing outputs for each simulation step
+		"""
+		self._write_step_output = False
 
 	def burn(self, prefix=None):
 		"""Burns the system
@@ -243,12 +248,13 @@ class Stand_alone(object):
 		for s in range(1, macrosteps_number+1):
 
 			print ('\n\n\n\n====== STEP {}======\n\n\n\n'.format(s))
-			sequence._gen_step_folder(s, prefix)
+			if self._write_step_output:
+                            sequence._gen_step_folder(s, prefix)
 			self._step_normalization(s)
 			print (('\n\n\n=== Salameche Burn {}===\n\n\n'.format(s)))
 			if self._xs_libs_set=='yes':
 				self.set_xs_lib(self._xs_libs[s-1])
-			salameche.burn_step(system, s, 'stand alone', prefix)
+			salameche.burn_step(system, s, 'stand alone', prefix, self._write_step_output)
 
 			# To develop. Basially update bu against time when doing constant flux
 			#sequence.dynamic_system_time_bu_conversion(system)


### PR DESCRIPTION
Added an option to disable ONIX outputs for each step, only retaining the output summary (which will still contain the information for all steps).
